### PR TITLE
Align the left to left in mobile mode.

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -22,7 +22,9 @@ only screen and (max-width: 640px){
 @media
 only screen and (max-width: 480px),
 (min-device-width: 320px) and (max-device-width: 480px)  {
-
+	.full-width-content .vertical-list-mobile {
+		text-align: left !important;
+	}
 	.full-width-content .vertical-list-mobile li{
 		display: inline-block !important;
 	}

--- a/wp-odm_profile_pages.php
+++ b/wp-odm_profile_pages.php
@@ -3,7 +3,7 @@
  * Plugin Name: ODM Profile Pages
  * Plugin URI: http://github.com/OpenDevelopmentMekong/odm_profile_pages
  * Description: Internal wordpress plugin for exposing custom content type for profile pages
- * Version: 2.4.0
+ * Version: 2.4.1
  * Author: Alex Corbi (mail@lifeformapps.com)
  * Author URI: http://www.lifeformapps.com
  * License: GPLv3.


### PR DESCRIPTION
Fixes issue #166 
The icons will be central on desktop, but left on mobile.