### PR TITLE
[IMP] Add external link to Dataset Download button

### DIFF
--- a/css/profile-pages.css
+++ b/css/profile-pages.css
@@ -721,31 +721,44 @@ table.no-bgcolor tr{
   margin: 3px 0 0;
 }
 
-.widget_download .nc_tweetContainer{
+button.download {
+  background: #7dd220 !important;
+}
+
+.widget_download .nc_tweetContainer {
   height: 35px !important;
 }
-.widget_download .button.download{
+
+.widget_download .button {
   padding: 8px 6px 0 !important;
   border-radius: 2px;
+  border: none;
   position: absolute;
   right: 215px;
 }
-.widget_download a.download span{
+
+.widget_download button.download {
+  cursor: pointer;
+  height: 2.54em;
+  padding: 0 .8em !important;
+}
+
+.widget_download a.download span,
+.widget_download button.download span {
   display: none;
 }
 
-.widget_download a.download:hover{
-  right: 215px;
-}
-.widget_download a.download:hover span{
+.widget_download a.download:hover span,
+.widget_download button.download:hover span {
   display: initial;
 }
-.widget_download a.download i{
+
+.widget_download a.download i {
   margin-right: 5px;
   margin-left: 5px;
 }
 
-.full-width-content ul{
+.full-width-content ul {
     padding: 5px 0;
 }
 

--- a/post-types/profile-pages.php
+++ b/post-types/profile-pages.php
@@ -100,6 +100,15 @@ if (!class_exists('Odm_Profile_Pages_Post_Type')) {
             );
 
             add_meta_box(
+                'external_url',
+                __('External Link', 'wp-odm_profile_pages'),
+                [$this, 'external_link_settings_box'],
+                'profiles',
+                'advanced',
+                'high'
+            );
+
+            add_meta_box(
                 'profiles_resource',
                 __('CKAN Dataset Resource', 'wp-odm_profile_pages'),
                 array($this, 'resource_settings_box'),
@@ -141,6 +150,18 @@ if (!class_exists('Odm_Profile_Pages_Post_Type')) {
                     <option <?php selected($template, 'with-sidebar-and-table') ?> value="with-sidebar-and-table">With sidebar and table</option>
                 </select>
             </div>
+        <?php
+        }
+
+        function external_link_settings_box($post)
+        {
+            $external_link = get_post_meta($post->ID, '_external_link', true); ?>
+
+            <label for="external_link">
+                <?php _e('External Link for attaching with "Download and Metadata" button', 'wp-odm_profile_pages'); ?>
+            </label>
+            <input type="text" id="external_link" name="_external_link" style="width: 100%" value="<?php echo $external_link; ?>" />
+
         <?php
         }
 
@@ -491,6 +512,10 @@ if (!class_exists('Odm_Profile_Pages_Post_Type')) {
                     update_post_meta($post_id, '_full_width_content_position', TRUE);
                 } else {
                     update_post_meta($post_id, '_full_width_content_position', FALSE);
+                }
+
+                if (isset($_POST['_external_link'])) {
+                    update_post_meta($post_id, '_external_link', sanitize_url($_POST['_external_link']));
                 }
 
                 if (isset($_POST['_csv_resource_url'])) {

--- a/post-types/templates/single-profiles.php
+++ b/post-types/templates/single-profiles.php
@@ -32,8 +32,9 @@ if (have_posts()) : the_post();
         $dataset = wpckan_api_package_show(wpckan_get_ckan_domain(), $ckan_dataset_id);
     }
 
-    $template = get_post_meta($post->ID, '_attributes_template_layout', true);
+    $template       = get_post_meta($post->ID, '_attributes_template_layout', true);
     $sub_navigation = get_post_meta($post->ID, '_page_with_sub_navigation', true);
+    $external_url   = get_post_meta($post->ID, '_external_link', true);
 
     if (!$sub_navigation) :
 ?>
@@ -56,7 +57,7 @@ if (have_posts()) : the_post();
                             <div class="four columns">
                                 <?php
                                 if (!empty($dataset)) :
-                                    echo_download_button_link_to_datapage($ckan_dataset_id);
+                                    echo_download_button_link_to_datapage($ckan_dataset_id, false, $external_url);
                                 endif;
                                 ?>
                             </div>

--- a/utils/utils.php
+++ b/utils/utils.php
@@ -194,24 +194,33 @@ function echo_metadata_button($dataset)
     <?php
 }
 
-function echo_download_button_link_to_datapage($dataset_id, $only_hyperlink = false)
+function echo_download_button_link_to_datapage($dataset_id, $only_hyperlink = false, $external_url = '')
 {
     if (!$only_hyperlink) : ?>
         <div class="nc_socialPanel widget_download swp_social_panel">
             <div class="nc_tweetContainer swp_fb">
             <?php endif; ?>
-            <a target="_blank" class="button download format" href="<?php echo get_bloginfo("url"); ?>/dataset/?id=<?php echo $dataset_id; ?>"><i class="fa fa-download"></i>
-                <span>
-                    <?php
-                    if (odm_screen_manager()->is_desktop()) :
-                        _e('Download and Metadata', 'wp-odm_profile_pages');
-                    endif; ?>
-                </span>
-            </a>
+
+            <?php if (empty($external_url)) : ?>
+                <a target="_blank" class="button download format" href="<?php echo get_bloginfo('url'); ?>/dataset/?id=<?php echo $dataset_id; ?>"><i class="fa fa-download"></i>
+                    <span>
+                        <?php
+                        if (odm_screen_manager()->is_desktop()) :
+                            _e('Download and Metadata', 'wp-odm_profile_pages');
+                        endif;
+                        ?>
+                    </span>
+                </a>
+            <?php else : ?>
+                <button type="submit" value="<?php _e('Download and Metadata', 'wp-odm_profile_pages'); ?>" name="<?php _e('Download and Metadata', 'wp-odm_profile_pages'); ?>" class="button download format" onclick="window.open('<?php echo $external_url; ?>'), window.location='<?php echo get_bloginfo('url'); ?>/dataset/?id=<?php echo $dataset_id; ?>'">
+                    <i class="fa fa-download"></i>
+                    <span><?php _e('Download and Metadata', 'wp-odm_profile_pages'); ?></span>
+                </button>
+            <?php endif; ?>
+
             <?php if (!$only_hyperlink) : ?>
             </div>
         </div>
     <?php endif; ?>
 <?php
 }
-?>


### PR DESCRIPTION
Fixed issue #234 

### Describe Changes
- Add a new metabox for input the an "External URL" to the "Download and Metadata" button
- If the external link is added from WP backend, redirect to CKAN Dataset page on current tab and open an external link on a new tab

### Type of Change
- [x] New feature

